### PR TITLE
Fix: Update Policies tab to Snapshot Policies link

### DIFF
--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -64,7 +64,7 @@ Now we'll set up a policy to automatically create frequent snapshots for ongoing
 
 ### **Create a Snapshot Policy**
 
-1. Still in **Cluster > Snapshots**, click the **"Policies"** tab
+1. Still in **Cluster > Snapshots**, click the **"Snapshot Policies"** link
 2. Click **"Create Policy"** button
 3. Configure the policy settings:
    


### PR DESCRIPTION
The UI shows 'Related page: Snapshot Policies' as a link, not a 'Policies' tab.

Fixes #36