### PR TITLE
Add monitoring tip to Scale Out/In Step 1

### DIFF
--- a/content/4_elasticity/42_scaleout.md
+++ b/content/4_elasticity/42_scaleout.md
@@ -34,6 +34,8 @@ Before adding nodes, ensure:
 
 ## **Step 1: Execute Node Addition**
 
+:::alert[**Tip**: Open the Qumulo GUI dashboard now before running the script so you can monitor the node addition in real-time.]{type="info"}
+
 ### **Script Execution**
 
 Run the automated node addition script:

--- a/content/4_elasticity/43_scalein.md
+++ b/content/4_elasticity/43_scalein.md
@@ -35,6 +35,8 @@ Before removing nodes, ensure:
 
 ## **Step 1: Execute Node Removal**
 
+:::alert[**Tip**: Open the Qumulo GUI dashboard now before running the script so you can monitor the node removal in real-time.]{type="info"}
+
 ### **Script Execution**
 
 Run the automated node removal script:


### PR DESCRIPTION
Students should open the Qumulo GUI dashboard before running the scale scripts so they can monitor the operation in real-time.

Added an alert box at the start of Step 1 in both:
- 42_scaleout.md
- 43_scalein.md

Fixes #34