### PR TITLE
Clarify Analytics dropdown menu navigation

### DIFF
--- a/content/3_qumulogui/33_analytics.md
+++ b/content/3_qumulogui/33_analytics.md
@@ -6,6 +6,8 @@ weight: 33
 
 The Analytics section provides comprehensive monitoring and insights into your Qumulo cluster's performance, capacity usage, and activity patterns. This powerful toolset helps administrators understand system behavior, identify bottlenecks, and make data-driven decisions.
 
+Use the **Analytics dropdown menu** (shown below) to navigate between the different analytics views: Integrated Analytics, Capacity Explorer, Capacity Trends, and Activity hotspots.
+
 ![Analytics Main Screen](/static/images/qumulogui/33_01.png)
 
 ## What Analytics Provides


### PR DESCRIPTION
Added instruction to use the Analytics dropdown menu to navigate between Integrated Analytics, Capacity Explorer, Capacity Trends, and Activity hotspots.

Fixes #32