### PR TITLE
Restore contentspec.yaml to GitHub repo

### DIFF
--- a/contentspec.yaml
+++ b/contentspec.yaml
@@ -1,0 +1,74 @@
+version: 2.0
+
+# BEGIN Locale
+defaultLocaleCode: en-US
+localeCodes:
+  - en-US
+# END Locale
+
+# A dictionary of arbitrary parameters that can be referenced in the workshop guide
+# using the params directive.
+params:
+  author: Qumulo team
+  description: Qumulo & AWS - Modernization Workshop
+
+# List of links to display in the workshop guide. Will be rendered on the left hand side navigation menu.
+additionalLinks:
+  - title: "AWS Modernization with Qumulo"
+    link: "https://qumulo-on-aws.awsworkshop.io/"
+
+# START Infrastructure
+infrastructure:
+  cloudformationTemplates:
+    - templateLocation: static/infrastructure/qumulo-workshop-deployment-cft.yaml
+      label: Qumulo Workshop CFT Template
+
+      #parameters:
+
+      #- templateParameter: AssetZipS3Path
+      #defaultValue: '{{.AssetsBucketName}}/{{.AssetsBucketPrefix}}workshop.zip'
+
+# END Infrastructure
+
+# START Accounts
+awsAccountConfig:
+  accountSources:
+    - workshop_studio
+  serviceLinkedRoles:
+    - appsync.amazonaws.com
+  participantRole:
+    #     iamPolicies:
+    #       - static/iam_policy.json
+    managedPolicies:
+      - "arn:aws:iam::aws:policy/AdministratorAccess"
+      - "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
+      - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+      - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+      - "arn:aws:iam::aws:policy/AmazonQDeveloperAccess"
+      - "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
+      - "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"
+      
+
+      
+    trustedPrincipals:
+      service:
+        - ec2.amazonaws.com
+        - codebuild.amazonaws.com
+        - lambda.amazonaws.com
+        - elasticloadbalancing.amazonaws.com
+        - ecs.amazonaws.com
+        - bedrock.amazonaws.com
+  regionConfiguration:
+    minAccessibleRegions: 1
+    maxAccessibleRegions: 3
+    accessibleRegions:
+      recommended:
+        - us-west-2
+        - us-east-1
+        - us-east-2
+    deployableRegions:
+      recommended:
+        - us-west-2
+        - us-east-1
+        - us-east-2
+# END Accounts


### PR DESCRIPTION
Restores `contentspec.yaml` which was accidentally deleted in PR #14 (Jan 14, 2026). The file has only existed in the Workshop Studio repo since then.

This is an exact copy of the current Workshop Studio version, identical to the last GitHub version (commit `81a88ee`, Dec 9, 2025).

Having this file in GitHub ensures:
- Single source of truth for workshop infrastructure config
- PR review for any IAM/security changes
- Simpler sync process to Workshop Studio

**Note:** The `AdministratorAccess` removal is tracked separately in #47.

Related: #47, #44