### PR TITLE
Remove AdministratorAccess from participantRole, add scoped IAM policy

### DIFF
--- a/contentspec.yaml
+++ b/contentspec.yaml
@@ -6,13 +6,10 @@ localeCodes:
   - en-US
 # END Locale
 
-# A dictionary of arbitrary parameters that can be referenced in the workshop guide
-# using the params directive.
 params:
   author: Qumulo team
   description: Qumulo & AWS - Modernization Workshop
 
-# List of links to display in the workshop guide. Will be rendered on the left hand side navigation menu.
 additionalLinks:
   - title: "AWS Modernization with Qumulo"
     link: "https://qumulo-on-aws.awsworkshop.io/"
@@ -22,12 +19,6 @@ infrastructure:
   cloudformationTemplates:
     - templateLocation: static/infrastructure/qumulo-workshop-deployment-cft.yaml
       label: Qumulo Workshop CFT Template
-
-      #parameters:
-
-      #- templateParameter: AssetZipS3Path
-      #defaultValue: '{{.AssetsBucketName}}/{{.AssetsBucketPrefix}}workshop.zip'
-
 # END Infrastructure
 
 # START Accounts
@@ -37,27 +28,16 @@ awsAccountConfig:
   serviceLinkedRoles:
     - appsync.amazonaws.com
   participantRole:
-    #     iamPolicies:
-    #       - static/iam_policy.json
+    iamPolicies:
+      - static/participant_policy.json
     managedPolicies:
-      - "arn:aws:iam::aws:policy/AdministratorAccess"
-      - "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
       - "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-      - "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
-      - "arn:aws:iam::aws:policy/AmazonQDeveloperAccess"
-      - "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess"
-      - "arn:aws:iam::aws:policy/AmazonBedrockFullAccess"
-      
-
-      
+      - "arn:aws:iam::aws:policy/IAMReadOnlyAccess"
     trustedPrincipals:
       service:
         - ec2.amazonaws.com
-        - codebuild.amazonaws.com
         - lambda.amazonaws.com
         - elasticloadbalancing.amazonaws.com
-        - ecs.amazonaws.com
-        - bedrock.amazonaws.com
   regionConfiguration:
     minAccessibleRegions: 1
     maxAccessibleRegions: 3

--- a/static/participant_policy.json
+++ b/static/participant_policy.json
@@ -1,0 +1,84 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "EC2ReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "ec2:Describe*"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "S3ReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "s3:ListAllMyBuckets",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:GetObject"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SSMSessionManager",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:StartSession",
+        "ssm:TerminateSession",
+        "ssm:ResumeSession",
+        "ssm:DescribeSessions",
+        "ssm:GetConnectionStatus"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "SSMParameterStoreRead",
+      "Effect": "Allow",
+      "Action": [
+        "ssm:GetParameter",
+        "ssm:GetParameters",
+        "ssm:DescribeParameters",
+        "ssm:DescribeInstanceInformation"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "FleetManagerRDP",
+      "Effect": "Allow",
+      "Action": [
+        "ssm-guiconnect:StartConnection",
+        "ssm-guiconnect:GetConnection"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "CloudFormationReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "cloudformation:DescribeStacks",
+        "cloudformation:DescribeStackResources",
+        "cloudformation:ListStacks"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "Route53ReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "route53:ListHostedZones",
+        "route53:ListResourceRecordSets",
+        "route53:GetHostedZone"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ELBReadOnly",
+      "Effect": "Allow",
+      "Action": [
+        "elasticloadbalancing:Describe*"
+      ],
+      "Resource": "*"
+    }
+  ]
+}


### PR DESCRIPTION
Fixes #47

Per AWS content security review feedback (Brian Benscoter, Feb 13), removes `AdministratorAccess` from the participant role and replaces it with a scoped IAM policy.

### What changed in `contentspec.yaml`:
- **Removed** `AdministratorAccess` managed policy
- **Removed** unused policies: `AmazonQDeveloperAccess`, `AmazonBedrockFullAccess`, `CloudWatchAgentServerPolicy`, `ElasticLoadBalancingFullAccess`
- **Removed** unused trusted principals: `codebuild`, `ecs`, `bedrock`
- **Removed** commented-out `iam_policy.json` reference and parameter blocks
- **Added** `iamPolicies: static/participant_policy.json`
- **Kept** `AmazonSSMManagedInstanceCore` and `IAMReadOnlyAccess`
- **Fixed** missing newline at end of file

### New file `static/participant_policy.json`:
Scoped to only what workshop participants need in the AWS console:
| Permission | Why |
|---|---|
| `ec2:Describe*` | View instances, AZs in EC2 console |
| `s3:List*, s3:Get*` | Browse S3 buckets in console |
| `ssm:StartSession, TerminateSession, ResumeSession` | Session Manager |
| `ssm:GetParameter, DescribeParameters` | Parameter Store in console |
| `ssm-guiconnect:*` | Fleet Manager RDP |
| `cloudformation:Describe*, List*` | View stacks |
| `route53:List*, Get*` | View hosted zones |
| `elasticloadbalancing:Describe*` | View NLBs |

### How we verified this is sufficient:
All 27 workshop markdown files were reviewed. Participants only:
- View EC2 instances, S3 buckets, SSM parameters in the AWS console
- Connect via SSM Session Manager and Fleet Manager RDP
- All infrastructure changes run via Terraform on the Linux instance (uses `EC2SSMRole`, not the participant role)

### ⚠️ After merging:
This file must be synced to the Workshop Studio repo and a new build triggered. The change should be tested with a test event to confirm participants can still complete all workshop steps.