### PR TITLE
Add language hints to code blocks for copy-to-clipboard support

### DIFF
--- a/content/10_cleanup/_index.md
+++ b/content/10_cleanup/_index.md
@@ -41,7 +41,7 @@ To execute the complete cleanup process, run the following command from your wor
 
 
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./cleanup-qumulo-environment.sh
 ```

--- a/content/2_deployment/22_storage_deploy.md
+++ b/content/2_deployment/22_storage_deploy.md
@@ -22,7 +22,7 @@ The persistent storage layer consists of multiple S3 buckets distributed across 
 
 Navigate to your workshop environment and examine the persistent storage configuration:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_saz/persistent-storage
 ls -la
 ```
@@ -39,7 +39,7 @@ You'll see the key files that define your persistent storage deployment:
 
 The `terraform.tfvars` file contains the specific configuration for your persistent storage deployment. Open this file to explore the key settings:
 
-```
+```bash
 cat terraform.tfvars
 ```
 
@@ -119,7 +119,7 @@ The persistent storage deployment creates several critical parameters:
 
 These parameters follow a specific naming convention:
 
-```
+```text
 /qumulo/{storage-deployment-name}{unique-identifier}/{parameter-name}
 ```
 
@@ -138,7 +138,7 @@ These parameters follow a specific naming convention:
 
 The persistent storage deployment creates a **local Terraform state file** that tracks the created resources, in a customer deployment it is recommended to use S3 state file storage:
 
-```
+```bash
 # View the state file (if curious)
 ls -la terraform.tfstate*
 

--- a/content/2_deployment/23_compute_deploy.md
+++ b/content/2_deployment/23_compute_deploy.md
@@ -22,7 +22,7 @@ The compute deployment demonstrates CNQ's flexible architecture - the same persi
 
 Navigate to your compute deployment directory and examine the configuration:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_saz
 ls -la
 ```
@@ -40,7 +40,7 @@ You'll see the compute infrastructure files alongside the persistent storage dir
 
 The compute `terraform.tfvars` file contains the specific configuration for your Qumulo cluster. Open this file to explore the key settings:
 
-```
+```bash
 cat terraform.tfvars
 ```
 
@@ -137,7 +137,7 @@ Floating IP addresses are **virtual IP addresses** that:
 
 Check your cluster's floating IP configuration:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_saz
 terraform output
 ```
@@ -172,7 +172,7 @@ For the purposes of this workshop we are utilizing round robin DNS in a private 
 
 The deployment stores detailed IP address information in Systems Manager Parameter Store for reference:
 
-```
+```bash
 # View cluster IP information from parameter store
 aws ssm get-parameters --names $(aws ssm describe-parameters --parameter-filters Key=Name,Values="/qumulo/qum-wks-cls-pri",Option=Contains --query "Parameters[?contains(Name, 'float-ips') || contains(Name, 'node-ips')].Name" --output text)
 ```
@@ -202,7 +202,7 @@ These can also be viewed in the AWS Console by navigating to Systems Manager, Pa
 With compute deployment complete, the next step is to verify cluster connectivity.  The workshop creates a text file named **`cluster-access-info.txt`** containing all connectivity information for the clusters deployed.  As you progress through the workshop the content of this file will change:
 
 **From the Linux Instance:**
-```
+```bash
 # Check cluster access information
 cat /home/ssm-user/qumulo-workshop/cluster-access-info.txt
 ```

--- a/content/4_elasticity/41_saztomaz.md
+++ b/content/4_elasticity/41_saztomaz.md
@@ -40,7 +40,7 @@ Before initiating the cluster replace process it is important to consider your o
 
 Execute the preparation script to generate the Multi-AZ configuration:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./primary-qumulo-cluster-saz-to-maz.sh
 ```
@@ -67,7 +67,7 @@ The script output will display:
 
 We can explore the newly created terraform workspace by this script:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz
 cat terraform.tfvars
 ```
@@ -89,7 +89,7 @@ You will notice the original cluster var file has been copied over and we've upd
 
 Now execute the cluster replace operation:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./cluster-replace.sh "/home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz" "Multi-AZ replacement cluster with NLB"
 ```
@@ -165,7 +165,7 @@ During the cluster replace operation, the script performs these additional steps
 
 Let's examine the terraform configuration file to understand what changed during the automated process:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz
 cat terraform.tfvars
 ```
@@ -198,7 +198,7 @@ After the automated cleanup completes, you can verify the process worked correct
 
 #### **Terraform State Verification**
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz
 terraform state list
 ```
@@ -230,7 +230,7 @@ Access the Qumulo GUI and monitor the following during the cluster replace opera
 ![cluster health](/static/images/elasticity/41_13.png)
 #### **Network Configuration**
 - **Floating IP address removal** examining the terraform output will show that the floating IPs were removed in favor of a network load balancer configuration:
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz/
 terraform output
 ```

--- a/content/4_elasticity/42_scaleout.md
+++ b/content/4_elasticity/42_scaleout.md
@@ -40,7 +40,7 @@ Before adding nodes, ensure:
 
 Run the automated node addition script:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./add-cluster-node.sh
 ```

--- a/content/4_elasticity/43_scalein.md
+++ b/content/4_elasticity/43_scalein.md
@@ -41,7 +41,7 @@ Before removing nodes, ensure:
 
 Run the automated node removal script:
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./remove-cluster-node.sh
 ```
@@ -109,7 +109,7 @@ The node removal script executes a **two-phase terraform process** to safely rem
 #### **Terraform Configuration Changes**
 The script first updates the terraform configuration to initiate node removal, this will not be visible after the node removal because our script performs the second step, but the initial configuration would look like the following:
 
-```
+```bash
 # View the current terraform configuration
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz
 cat terraform.tfvars | grep -E "q_node_count|q_target_node_count"
@@ -153,7 +153,7 @@ After successful node removal from the cluster, the script updates the configura
 - q_node_count = 3
 - q_target_node_count = null
 
-```
+```bash
 # View the current terraform configuration
 cd /home/ssm-user/qumulo-workshop/terraform_deployment_primary_maz
 cat terraform.tfvars | grep -E "q_node_count|q_target_node_count"

--- a/content/5_haanddr/51_drclustercreate.md
+++ b/content/5_haanddr/51_drclustercreate.md
@@ -13,7 +13,7 @@ You will build that cluster with two helper scripts that ship with the workshop 
 
 ## Generate Terraform config
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./secondary-qumulo-cluster-tf-configuration.sh
 ```
@@ -35,7 +35,7 @@ Inspect `compute.tfvars` if you are curious; note the variable `node_count = 1` 
 
 ## Deploy the cluster
 
-```
+```bash
 cd /home/ssm-user/qumulo-workshop/scripts
 ./deploy-qumulo-cluster.sh /home/ssm-user/qumulo-workshop/terraform_deployment_secondary "Secondary Workshop Qumulo One Node Instance"
 ```
@@ -66,7 +66,7 @@ The workshop Linux instance already has the Qumulo command-line tool **`qq`** in
 
 ### Log in to the primary cluster
 
-```
+```bash
 qq --host demopri.qumulo.local login --u admin --p '!Qumulo123'
 qq --host demopri.qumulo.local nodes_list
 ```
@@ -77,7 +77,7 @@ The second command returns the node table for the primary (multi-node) cluster.
 
 ### Log in to the new secondary cluster
 
-```
+```bash
 qq --host demosec.qumulo.local login --u admin --p '!Qumulo123'
 qq --host demosec.qumulo.local nodes_list
 ```

--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -128,7 +128,7 @@ Policy-generated snapshots use automatic naming:
 
 Connect the Windows system to the share as the admin user: Open **PowerShell** and run:
 
-```
+```powershell
 net use \\demopri.qumulo.local\userdata /delete /y
 net use \\demopri.qumulo.local\userdata /user:admin !Qumulo123
 ```
@@ -162,14 +162,14 @@ Since the Analytics > Capacity Trends page updates only hourly, we'll use the `q
 
 On your **Linux workshop instance**, open a terminal and run:
 
-```
+```bash
 qq --host demopri.qumulo.local login --u admin --p '!Qumulo123'
 qq --host demopri.qumulo.local snapshot_get_total_used_capacity
 ```
 
 ![total space consumption](/static/images/haanddr/52_10.png)
 
-```
+```bash
 qq --host demopri.qumulo.local snapshot_list_statuses | jq --argjson capacity "$(qq --host demopri.qumulo.local snapshot_get_capacity_used_per_snapshot)" '.entries[] as $snap | $capacity.entries[] | select(.id == $snap.id) | {name: $snap.name, capacity_MB: ((.capacity_used_bytes | tonumber) / 1024 / 1024 | floor), capacity_bytes: (.capacity_used_bytes | tonumber)}' | jq -s 'sort_by(.capacity_bytes) | reverse[]'
 ```
 
@@ -187,7 +187,7 @@ This command shows each snapshot with its storage consumption in both megabytes 
 
 3. Run the snapshot space command again to see how deleted data affects snapshot storage:
 
-```
+```bash
 qq --host demopri.qumulo.local login --u admin --p '!Qumulo123'
 qq --host demopri.qumulo.local snapshot_get_total_used_capacity
 qq --host demopri.qumulo.local snapshot_list_statuses | jq --argjson capacity "$(qq --host demopri.qumulo.local snapshot_get_capacity_used_per_snapshot)" '.entries[] as $snap | $capacity.entries[] | select(.id == $snap.id) | {name: $snap.name, capacity_MB: ((.capacity_used_bytes | tonumber) / 1024 / 1024 | floor), capacity_bytes: (.capacity_used_bytes | tonumber)}' | jq -s 'sort_by(.capacity_bytes) | reverse[]'
@@ -206,7 +206,7 @@ Qumulo makes snapshots accessible through a special hidden directory that client
 1. In **File Explorer**, navigate to the primary Qumulo cluster userdata share.
 2. Type the following path in the address bar:
 
-```
+```text
 \\demopri.qumulo.local\userdata\.snapshot
 ```
 

--- a/content/5_haanddr/53_replication.md
+++ b/content/5_haanddr/53_replication.md
@@ -209,7 +209,7 @@ The destination share needs to be created.
 
 2. **Connect your Windows desktop SMB to the userdata share with admin privileges**
 
-```
+```powershell
 net use \\demopri.qumulo.local\userdata /delete /y
 net use \\demosec.qumulo.local\userdata /delete /y
 net use \\demopri.qumulo.local\userdata /user:admin !Qumulo123
@@ -269,7 +269,7 @@ You can use the `qq` CLI to get detailed replication status as well:
 
 **Retrieve Source Relationships**
 
-```
+```bash
 qq --host demopri.qumulo.local login --u admin --p '!Qumulo123'
 qq --host demopri.qumulo.local replication_list_source_relationships
 ```
@@ -280,7 +280,7 @@ Make note of the replication relationship ID
 
 :::alert[**Tip**: Get specific information about a source relationship using the command below. Make sure to replace `insert_id_here` with your actual replication ID.]{type="info"}
 
-```
+```bash
 qq --host demopri.qumulo.local login --u admin --p '!Qumulo123'
 # Make sure to enter your specific replication ID into the following command
 qq --host demopri.qumulo.local replication_get_source_relationship_status --id "insert_id_here"

--- a/content/6_cdf/_index.md
+++ b/content/6_cdf/_index.md
@@ -30,7 +30,7 @@ CDF synchronizes **metadata instantly** while transferring **file data blocks** 
 
 Connect your Windows workstation (`qumulo-workshop-windows-instance`) SMB to the userdata share with admin privileges
 
-```
+```powershell
 net use \\demopri.qumulo.local\userdata /delete /y
 net use \\demosec.qumulo.local\userdata /delete /y
 net use \\demopri.qumulo.local\userdata /user:admin !Qumulo123
@@ -41,7 +41,7 @@ net use \\demosec.qumulo.local\userdata /user:admin !Qumulo123
 
 Use this PowerShell script to create some sample content:
 
-```
+```powershell
 $basePath = "\\demopri.qumulo.local\userdata\GlobalData"
 New-Item -Path "$basePath" -ItemType Directory
 # Use the .NET RandomNumberGenerator class for cryptographically strong randomness
@@ -73,7 +73,7 @@ for ($i=1; $i -le 30; $i++) {
 
 From your Linux instance (`qumulo-workshop-linux-instance`), run the following bash script to set up a read / write portal to link `/userdata/GlobalData` between your primary (`demopri`) and secondary (`demosec`) clusters:
 
-```
+```bash
 export PATH="$HOME/.local/bin:$PATH"
 # Resolve IP addresses for demopri and demosec clusters
 demopri_ip=$(nslookup demopri.qumulo.local | awk '/^Address: / {print $2}' | tail -n1)
@@ -126,7 +126,7 @@ Connect to your Windows remote desktop and access the spoke:
 
 Create a new data on the hub, then verify immediate presence on the spoke:
 
-```
+```powershell
 $basePath = "\\demopri.qumulo.local\userdata\GlobalData\HubAdds"
 New-Item -Path "$basePath" -ItemType Directory
 # Use the .NET RandomNumberGenerator class for cryptographically strong randomness
@@ -162,7 +162,7 @@ Check for new data on the spoke that was created in the hub.  Notice the size on
 
 Create some new data on the Spoke and check presence on the Hub:
 
-```
+```powershell
 $basePath = "\\demosec.qumulo.local\userdata\GlobalData\SpokeAdds"
 New-Item -Path "$basePath" -ItemType Directory
 # Use the .NET RandomNumberGenerator class for cryptographically strong randomness


### PR DESCRIPTION
## Summary

Workshop Studio only enables the copy-to-clipboard button and line numbers on fenced code blocks that specify a language (per [Workshop Studio code directive docs](https://studio.us-east-1.prod.workshops.aws/docs/detailed-documentation/directives/code)):

> In most situations, you can simply use the regular markdown code block declaration. If a language is specified, line numbers and copy action will be enabled automatically.

All 37 code blocks across 10 content files were using bare ``````` fences with no language, so no copy buttons were rendered in Workshop Studio.

## Changes

Added language hints to every fenced code block:
- `bash` — Linux CLI commands, qq CLI, terraform, shell scripts (27 blocks)
- `powershell` — Windows net use commands, PowerShell scripts (7 blocks)
- `text` — Non-executable reference strings like parameter paths and UNC paths (2 blocks)
- `bash` was already present on 1 block (31_getting_started.md)

## Files changed (10)
- `content/2_deployment/22_storage_deploy.md`
- `content/2_deployment/23_compute_deploy.md`
- `content/4_elasticity/41_saztomaz.md`
- `content/4_elasticity/42_scaleout.md`
- `content/4_elasticity/43_scalein.md`
- `content/5_haanddr/51_drclustercreate.md`
- `content/5_haanddr/52_snapshots.md`
- `content/5_haanddr/53_replication.md`
- `content/6_cdf/_index.md`
- `content/10_cleanup/_index.md`

Closes #68