### PR TITLE
Add Fleet Manager RDP permissions to participant policy

### DIFF
--- a/static/participant_policy.json
+++ b/static/participant_policy.json
@@ -5,7 +5,8 @@
       "Sid": "EC2ReadOnly",
       "Effect": "Allow",
       "Action": [
-        "ec2:Describe*"
+        "ec2:Describe*",
+        "ec2:GetPasswordData"
       ],
       "Resource": "*"
     },
@@ -28,7 +29,10 @@
         "ssm:TerminateSession",
         "ssm:ResumeSession",
         "ssm:DescribeSessions",
-        "ssm:GetConnectionStatus"
+        "ssm:GetConnectionStatus",
+        "ssm:DescribeInstanceProperties",
+        "ssm:GetCommandInvocation",
+        "ssm:GetInventorySchema"
       ],
       "Resource": "*"
     },
@@ -47,8 +51,10 @@
       "Sid": "FleetManagerRDP",
       "Effect": "Allow",
       "Action": [
+        "ssm-guiconnect:CancelConnection",
+        "ssm-guiconnect:GetConnection",
         "ssm-guiconnect:StartConnection",
-        "ssm-guiconnect:GetConnection"
+        "ssm-guiconnect:ListConnections"
       ],
       "Resource": "*"
     },


### PR DESCRIPTION
## Problem

Fleet Manager RDP fails for workshop participants. When connecting to the Windows instance via Fleet Manager, the UI calls `ec2:GetPasswordData` to retrieve the Administrator password, which returns **Access Denied** because the action is missing from `participant_policy.json`.

Confirmed via live testing with participant role credentials (WSParticipantRole) against instance `i-0e3ed00bc794ac277`.

## Changes

**`static/participant_policy.json`** — 6 permissions added:

| Action | Why |
|---|---|
| `ec2:GetPasswordData` | Required for Fleet Manager to decrypt Windows password. **This was the Access Denied.** |
| `ssm:DescribeInstanceProperties` | Fleet Manager UI uses this to list managed nodes |
| `ssm:GetCommandInvocation` | Fleet Manager UI dependency |
| `ssm:GetInventorySchema` | Fleet Manager UI dependency |
| `ssm-guiconnect:CancelConnection` | Clean disconnect from RDP sessions |
| `ssm-guiconnect:ListConnections` | View connection history in Fleet Manager |

## Validation

- All 6 actions verified against the Workshop Studio Blocked API List (updated 2026-03-26) — **none are blocked**
- Permissions align with [AWS Fleet Manager RDP IAM policy examples](https://docs.aws.amazon.com/systems-manager/latest/userguide/fleet-rdp.html#rdp-iam-policy-examples)

## Testing

Requires a new test event to validate. After merge + Workshop Studio sync, create a test event and verify Fleet Manager RDP connect to the Windows instance using participant credentials.

Closes #61