### PR TITLE
Fix Windows instance EBS encryption — correct DeviceName to /dev/sda1

### DIFF
--- a/static/infrastructure/qumulo-workshop-deployment-cft.yaml
+++ b/static/infrastructure/qumulo-workshop-deployment-cft.yaml
@@ -981,7 +981,7 @@ Resources:
       SecurityGroupIds:
         - !Ref DefaultInstanceSecurityGroup
       BlockDeviceMappings:
-        - DeviceName: /dev/xvda
+        - DeviceName: /dev/sda1
           Ebs:
             Encrypted: true
             VolumeSize: 30


### PR DESCRIPTION
## Problem

The Windows instance root volume is not encrypted despite `Encrypted: true` in BlockDeviceMappings.

The CFT specifies `DeviceName: /dev/xvda` (line 984) but the Windows AMI (`Windows_Server-2025-English-Full-Base`) uses `/dev/sda1` as its root device. This causes CloudFormation to create a second encrypted volume at `/dev/xvda` while the actual boot volume at `/dev/sda1` remains unencrypted.

Confirmed via live testing — 6/7 instances had encrypted root volumes, Windows was the only failure.

## Fix

One-line change: `DeviceName: /dev/xvda` → `DeviceName: /dev/sda1` for the `WindowsInstance` resource only. All other instances (Linux + 5 load generators) correctly use `/dev/xvda`.

## Downstream impact

None. No scripts, content, or other CFT resources reference the Windows device name.

Fixes #73