### PR TITLE
Fix Edge typo and duplicate Terraform curl from PR #75

### DIFF
--- a/content/5_haanddr/53_replication.md
+++ b/content/5_haanddr/53_replication.md
@@ -89,7 +89,7 @@ Now let's create a continuous replication relationship between your primary and 
 
 1. On your **Windows workstation**, open Edge and access the **Primary Qumulo GUI** (`https://demopri.qumulo.local`)
 2. Log in with username `admin` and password contained in Secrets Manager or in your Linux environment variable file.
-3. On your **Windows workstation**, open a new E tab and access the **Secondary Qumulo GUI** (`https://demosec.qumulo.local`)
+3. On your **Windows workstation**, open a new Edge tab and access the **Secondary Qumulo GUI** (`https://demosec.qumulo.local`)
 4. Log in with username `admin` and password contained in Secrets Manager or in your Linux environment variable file.
 
 ### **Navigate to Replication on the Primary Qumulo Cluster**

--- a/static/infrastructure/qumulo-workshop-deployment-cft.yaml
+++ b/static/infrastructure/qumulo-workshop-deployment-cft.yaml
@@ -812,8 +812,7 @@ Resources:
           echo "Installing essential packages..."
           dnf install -y --skip-broken wget unzip git vim htop tree jq python3 python3-pip
           
-          # Get latest Terraform version and install (hardcoded for a race condition)
-          TERRAFORM_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.version')
+          # Get latest Terraform version and install (with fallback for API unavailability)
           TERRAFORM_VERSION=$(curl -s https://api.releases.hashicorp.com/v1/releases/terraform/latest | jq -r '.version')
           if [ -z "$TERRAFORM_VERSION" ] || [ "$TERRAFORM_VERSION" = "null" ]; then
             TERRAFORM_VERSION="1.14.8"


### PR DESCRIPTION
Fixes two issues introduced in PR #75:

1. **53_replication.md line 92**: Truncated word — `open a new E tab` → `open a new Edge tab`
2. **CFT UserData**: Duplicate `TERRAFORM_VERSION=$(curl ...)` line (called twice, first result overwritten). Removed duplicate and clarified comment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.