### PR TITLE
Use Workshop Studio key pair instead of custom EC2 KeyPair — Closes #56

### DIFF
--- a/contentspec.yaml
+++ b/contentspec.yaml
@@ -19,10 +19,14 @@ infrastructure:
   cloudformationTemplates:
     - templateLocation: static/infrastructure/qumulo-workshop-deployment-cft.yaml
       label: Qumulo Workshop CFT Template
+      parameters:
+        - templateParameter: EC2KeyPairName
+          defaultValue: "{{.EC2KeyPairName}}"
 # END Infrastructure
 
 # START Accounts
 awsAccountConfig:
+  ec2KeyPair: true
   accountSources:
     - workshop_studio
   serviceLinkedRoles:

--- a/static/infrastructure/qumulo-workshop-deployment-cft.yaml
+++ b/static/infrastructure/qumulo-workshop-deployment-cft.yaml
@@ -34,6 +34,11 @@ Parameters:
     Default: "0aGc1269bB5vEYxdzbKtFyijQn6RZ6jHzFvapWll"
     NoEcho: true
 
+  EC2KeyPairName:
+    Type: String
+    Description: Name of the EC2 key pair provided by Workshop Studio
+    Default: "ws-default-keypair"
+
 Resources:
 
   QumuloVPC:
@@ -332,15 +337,6 @@ Resources:
         - Key: Name
           Value: qumulo-workshop-vpce-s3
 
-  # New EC2 KeyPair resource
-  QumuloWorkshopKeyPair:
-    Type: AWS::EC2::KeyPair
-    Properties:
-      KeyName: qumulo-workshop-keypair
-      Tags:
-        - Key: Name
-          Value: qumulo-workshop-keypair
-
   #QumuloSecretsManager Password Declaration
   QumuloEnvironmentPassword:
     Type: AWS::SecretsManager::Secret
@@ -399,8 +395,7 @@ Resources:
                   - !Sub "arn:aws:s3:::${WorkshopUtilityBucket}/*"
 
               # ------------------------------------------------------------------
-              # Workshop: SSM parameter access (stack + keypair)
-              # /${StackName}/* for environment; /ec2/keypair/* for SSH private key
+              # Workshop: SSM parameter access (stack parameters)
               # ------------------------------------------------------------------
               - Effect: Allow
                 Action:
@@ -408,7 +403,6 @@ Resources:
                   - ssm:GetParameters
                 Resource:
                   - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/${AWS::StackName}/*"
-                  - !Sub "arn:aws:ssm:${AWS::Region}:${AWS::AccountId}:parameter/ec2/keypair/*"
 
               # ------------------------------------------------------------------
               # S3 - Qumulo/QPS buckets (scoped to Qumulo namespaces)
@@ -764,7 +758,7 @@ Resources:
   LinuxInstance:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
       InstanceType: m5.large
       IamInstanceProfile: !Ref EC2SSMInstanceProfile
@@ -899,7 +893,7 @@ Resources:
   WindowsInstance:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-windows-latest/Windows_Server-2025-English-Full-Base}}'
       InstanceType: t3.xlarge
       IamInstanceProfile: !Ref EC2SSMInstanceProfile
@@ -1018,7 +1012,7 @@ Resources:
   LoadTestingInstance1:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
       InstanceType: t3.medium
       IamInstanceProfile: !Ref EC2SSMInstanceProfile
@@ -1063,7 +1057,7 @@ Resources:
     Type: AWS::EC2::Instance
     Properties:
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       InstanceType: t3.medium
       SubnetId: !Ref PrivateSubnetB
       SecurityGroupIds:
@@ -1106,7 +1100,7 @@ Resources:
   LoadTestingInstance3:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
       InstanceType: t3.medium
       SubnetId: !Ref PrivateSubnetC
@@ -1150,7 +1144,7 @@ Resources:
   LoadTestingInstance4:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
       InstanceType: t3.medium
       SubnetId: !Ref PrivateSubnetA
@@ -1194,7 +1188,7 @@ Resources:
   LoadTestingInstance5:
     Type: AWS::EC2::Instance
     Properties:
-      KeyName: !Ref QumuloWorkshopKeyPair
+      KeyName: !Ref EC2KeyPairName
       ImageId: !Sub '{{resolve:ssm:/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-6.1-x86_64}}'
       InstanceType: t3.medium
       SubnetId: !Ref PrivateSubnetB
@@ -1364,14 +1358,6 @@ Resources:
       Value: !Ref WorkshopUtilityBucket
       Description: Workshop utility bucket name
 
-  PrivateKeyIdParameter:
-    Type: AWS::SSM::Parameter
-    Properties:
-      Name: !Sub "/${AWS::StackName}/private-key-id"
-      Type: String
-      Value: !GetAtt QumuloWorkshopKeyPair.KeyPairId
-      Description: Private key ID for workshop instances
-
   StackNameParameter:
     Type: AWS::SSM::Parameter
     Properties:
@@ -1505,24 +1491,6 @@ Outputs:
     Description: Status of workshop content copy operation
     Value: !Ref CopyWorkshopFiles
     
-  QumuloWorkshopKeyPair:
-    Description: Name of the created KeyPair for Qumulo workshop
-    Value: !Ref QumuloWorkshopKeyPair
-    Export:
-      Name: !Sub "${AWS::StackName}-KeyPair"
-  
-  QumuloWorkshopKeyPairId:
-    Description: ID of the created KeyPair (for SSM Parameter Store access)
-    Value: !GetAtt QumuloWorkshopKeyPair.KeyPairId
-    Export:
-      Name: !Sub "${AWS::StackName}-KeyPairId"
-  
-  PrivateKeySSMParameter:
-    Description: SSM Parameter Store path for the private key
-    Value: !Sub "/ec2/keypair/${QumuloWorkshopKeyPair.KeyPairId}"
-    Export:
-      Name: !Sub "${AWS::StackName}-PrivateKeyParameter"
-  
   ParameterStorePrefix:
     Description: Parameter Store prefix for all workshop variables
     Value: !Sub "/${AWS::StackName}/"
@@ -1570,12 +1538,6 @@ Outputs:
     Value: !Sub "/${AWS::StackName}/utility-bucket-name"
     Export:
       Name: !Sub "${AWS::StackName}-WorkshopUtilityBucketParameter"
-  
-  PrivateKeyIdParameter:
-    Description: SSM Parameter Store path for Private Key ID
-    Value: !Sub "/${AWS::StackName}/private-key-id"
-    Export:
-      Name: !Sub "${AWS::StackName}-PrivateKeyIdParameter"
   
   StackNameParameter:
     Description: SSM Parameter Store path for Stack Name

--- a/static/scripts/initial-qumulo-cluster-tf-configuration.sh
+++ b/static/scripts/initial-qumulo-cluster-tf-configuration.sh
@@ -72,7 +72,6 @@ load_variables() {
   # Extract variables from JSON file
   AWS_REGION=$(jq -r '.AWSRegion' "$VARIABLES_FILE")
   VPC_ID=$(jq -r '.VPCId' "$VARIABLES_FILE")
-  PRIVATE_KEY_ID=$(jq -r '.PrivateKeyID' "$VARIABLES_FILE")
   PRIVATE_SUBNET_A=$(jq -r '.PrivateSubnetA' "$VARIABLES_FILE")
   PRIVATE_SUBNET_B=$(jq -r '.PrivateSubnetB' "$VARIABLES_FILE")
   PRIVATE_SUBNET_C=$(jq -r '.PrivateSubnetC' "$VARIABLES_FILE")
@@ -80,8 +79,8 @@ load_variables() {
   WORKSHOP_PASSWORD=$(jq -r '.QumuloPassword' "$VARIABLES_FILE")
   QUMULO_VERSION=$(jq -r '.QumuloVersion' "$VARIABLES_FILE")
 
-  # Lookup Private Key Name from ID with AWS CLI
-  KEY_NAME=$(aws ec2 describe-key-pairs --key-pair-ids "$PRIVATE_KEY_ID" --region "$AWS_REGION" --query 'KeyPairs[0].KeyName' --output text)
+  # Key pair name provided by Workshop Studio
+  KEY_NAME=$(jq -r '.KeyPairName' "$VARIABLES_FILE")
 
   # Randomly select one of the three private subnets
   SUBNETS=("$PRIVATE_SUBNET_A" "$PRIVATE_SUBNET_B" "$PRIVATE_SUBNET_C")
@@ -91,7 +90,7 @@ load_variables() {
   log_info "Loaded variables:"
   log_info "  AWS Region: $AWS_REGION"
   log_info "  VPC ID: $VPC_ID"
-  log_info "  Private Key ID: $PRIVATE_KEY_ID"
+  log_info "  Key Pair Name: $KEY_NAME"
   log_info "  Available Subnets: A=$PRIVATE_SUBNET_A, B=$PRIVATE_SUBNET_B, C=$PRIVATE_SUBNET_C"
   log_info "  Randomly Selected Subnet: $SELECTED_SUBNET (Index: $RANDOM_INDEX)"
   log_info "  Workshop Utility Bucket: $WORKSHOP_UTILITY_BUCKET"

--- a/static/scripts/secondary-qumulo-cluster-tf-configuration.sh
+++ b/static/scripts/secondary-qumulo-cluster-tf-configuration.sh
@@ -78,19 +78,18 @@ load_variables() {
   # Extract variables from JSON file
   AWS_REGION=$(jq -r '.AWSRegion' "$VARIABLES_FILE")
   VPC_ID=$(jq -r '.VPCId' "$VARIABLES_FILE")
-  PRIVATE_KEY_ID=$(jq -r '.PrivateKeyID' "$VARIABLES_FILE")
   PRIVATE_SUBNET_A=$(jq -r '.PrivateSubnetA' "$VARIABLES_FILE")
   WORKSHOP_UTILITY_BUCKET=$(jq -r '.WorkshopUtilityBucket' "$VARIABLES_FILE")
   WORKSHOP_PASSWORD=$(jq -r '.QumuloPassword' "$VARIABLES_FILE")
   QUMULO_VERSION=$(jq -r '.QumuloVersion' "$VARIABLES_FILE")
 
-  # Lookup Private Key Name from ID with AWS CLI
-  KEY_NAME=$(aws ec2 describe-key-pairs --key-pair-ids "$PRIVATE_KEY_ID" --region "$AWS_REGION" --query 'KeyPairs[0].KeyName' --output text)
+  # Key pair name provided by Workshop Studio
+  KEY_NAME=$(jq -r '.KeyPairName' "$VARIABLES_FILE")
 
   log_info "Loaded variables:"
   log_info "  AWS Region: $AWS_REGION"
   log_info "  VPC ID: $VPC_ID"
-  log_info "  Private Key ID: $PRIVATE_KEY_ID"
+  log_info "  Key Pair Name: $KEY_NAME"
   log_info "  Private Subnet A: $PRIVATE_SUBNET_A"
   log_info "  Workshop Utility Bucket: $WORKSHOP_UTILITY_BUCKET"
   log_info "  Workshop Password: $WORKSHOP_PASSWORD"

--- a/static/scripts/setup-workshop-environment.sh
+++ b/static/scripts/setup-workshop-environment.sh
@@ -207,7 +207,6 @@ get_cloudformation_variables() {
     AWS_REGION_PARAM=$(get_parameter "/${stack_name}/aws-region" "$region")
     DEFAULT_SECURITY_GROUP=$(get_parameter "/$stack_name/default-instance-security-group" "$region")
     UTILITY_BUCKET=$(get_parameter "/${stack_name}/utility-bucket-name" "$region")
-    PRIVATE_KEY_ID=$(get_parameter "/${stack_name}/private-key-id" "$region")
     STACK_NAME_PARAM=$(get_parameter "/${stack_name}/stack-name" "$region")
     ACCOUNT_ID=$(get_parameter "/${stack_name}/account-id" "$region")
     #QUMULO_PASSWD=$(get_parameter "/${stack_name}/qumulo-environment-password" "$region")
@@ -250,7 +249,6 @@ get_cloudformation_variables() {
     echo "  AWS Region: $AWS_REGION" >&2
     echo "  Default Security Group: $DEFAULT_SECURITY_GROUP" >&2
     echo "  Utility Bucket: $UTILITY_BUCKET" >&2
-    echo "  Private Key ID: $PRIVATE_KEY_ID" >&2
     echo "  Stack Name: $STACK_NAME_PARAM" >&2
     echo "  Account ID: $ACCOUNT_ID" >&2
     echo "  Qumulo Environment Password: $QUMULO_PASSWD" >&2
@@ -264,30 +262,6 @@ get_cloudformation_variables() {
     echo "" >&2
     
     return 0
-}
-
-# Function to retrieve and save private key
-retrieve_private_key() {
-    local private_key_id="$1"
-    local region="$2"
-    
-    print_status "Retrieving SSH private key..."
-    if [ -n "$private_key_id" ]; then
-        PRIVATE_KEY_PARAM="/ec2/keypair/$private_key_id"
-        print_status "Downloading private key from parameter: $PRIVATE_KEY_PARAM"
-
-        if aws ssm get-parameter --name "$PRIVATE_KEY_PARAM" --with-decryption --query Parameter.Value --output text --region "$region" > /home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem 2>/dev/null; then
-            chmod 600 /home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem
-            print_status "Private key saved to: /home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem"
-            return 0
-        else
-            print_warning "Could not retrieve private key from Parameter Store"
-            return 1
-        fi
-    else
-        print_warning "Private Key ID not found in Parameter Store"
-        return 1
-    fi
 }
 
 # Function to create environment files
@@ -316,8 +290,7 @@ export DefaultSecurityGroup="$DEFAULT_SECURITY_GROUP"
 
 # Workshop Resources
 export WorkshopUtilityBucket="$UTILITY_BUCKET"
-export PrivateKeyID="$PRIVATE_KEY_ID"
-export PrivateKeyFile="/home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem"
+export KeyPairName="ws-default-keypair"
 export QumuloPassword="$QUMULO_PASSWD"
 export QumuloVersion="$QUMULO_VERSION"
 export LoadTestInstance1ID="$LOAD_INSTANCE_1_ID"
@@ -333,7 +306,7 @@ export AccountId="$ACCOUNT_ID"
 # Usage Instructions
 echo "CloudFormation variables loaded automatically"
 echo "Variables file: /home/ssm-user/qumulo-workshop/cloudformation-variables.env"
-echo "Private key: /home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem"
+echo "Key pair name: ws-default-keypair"
 echo "Qumulo version: $QUMULO_VERSION"
 VARS_EOF
 
@@ -348,8 +321,7 @@ VARS_EOF
   "AWSRegion": "$region",
   "DefaultSecurityGroup": "$DEFAULT_SECURITY_GROUP",
   "WorkshopUtilityBucket": "$UTILITY_BUCKET",
-  "PrivateKeyID": "$PRIVATE_KEY_ID",
-  "PrivateKeyFile": "/home/ssm-user/qumulo-workshop/qumulo-workshop-keypair.pem",
+  "KeyPairName": "ws-default-keypair",
   "StackName": "$STACK_NAME_PARAM",
   "AccountId": "$ACCOUNT_ID",
   "GeneratedAt": "$(date -Iseconds)",
@@ -448,12 +420,7 @@ main() {
         exit 1
     fi
     
-    # Step 4: Retrieve Private Key
-    if ! retrieve_private_key "$PRIVATE_KEY_ID" "$AWS_REGION"; then
-        print_warning "Private key retrieval failed, continuing without it"
-    fi
-    
-    # Step 5: Create Environment Files
+    # Step 4: Create Environment Files
     if ! create_environment_files "$STACK_NAME" "$AWS_REGION"; then
         print_error "Failed to create environment files"
         exit 1


### PR DESCRIPTION
Replaces the custom `QumuloWorkshopKeyPair` (`AWS::EC2::KeyPair`) with Workshop Studio's built-in `ec2KeyPair` mechanism, as agreed with Aaron Dailey on March 26.

## Changes

**contentspec.yaml:**
- Add `ec2KeyPair: true` under `awsAccountConfig`
- Add parameter mapping: `EC2KeyPairName` → `{{.EC2KeyPairName}}`

**CFT (6 changes):**
1. Add `EC2KeyPairName` parameter (default: `ws-default-keypair`)
2. Delete `QumuloWorkshopKeyPair` resource
3. Delete `PrivateKeyIdParameter` SSM resource
4. Replace 7× `KeyName: !Ref QumuloWorkshopKeyPair` → `!Ref EC2KeyPairName`
5. Remove `/ec2/keypair/*` ARN from EC2SSMRole IAM policy
6. Delete 3 Outputs (KeyPair, KeyPairId, PrivateKeySSMParameter)

**Scripts (3 files):**
- `setup-workshop-environment.sh`: Remove `retrieve_private_key()` function, remove `private-key-id` SSM lookup, export `KeyPairName` instead of `PrivateKeyID`/`PrivateKeyFile`
- `initial-qumulo-cluster-tf-configuration.sh`: Read `KeyPairName` from JSON directly (no more `describe-key-pairs` API call)
- `secondary-qumulo-cluster-tf-configuration.sh`: Same

## How it works
Workshop Studio creates `ws-default-keypair` during account provisioning and passes the name into the CFT via the `{{.EC2KeyPairName}}` magic variable. Participants download the private key from the Workshop Studio dashboard.

Closes #56

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.