### PR TITLE
Change cost table from monthly to hourly pricing

### DIFF
--- a/content/_index.md
+++ b/content/_index.md
@@ -44,21 +44,21 @@ The diagram below illustrates the environment that is deployed throughout the wo
 ![workshop architecture](/static/images/qumulo-workshop-diagram.png)
 
 ## **Estimated Workshop Cost**
-This workshop is designed to be cost-effective. However, please note that running AWS resources may incur charges based on usage. The estimated cost for this workshop is approximately $48 per day ($1,433.25 per month), depending on the duration and the specific AWS services utilized.  In a production environment the customer will also incur metered usage for Qumulo software on top of the referenced AWS infrastructure charges. For detailed Qumulo cost estimation please visit the Qumulo AWS TCO Calculator: https://qumulo.com/product/aws/cnq-tco-calculator/  
+This workshop is designed to be cost-effective. However, please note that running AWS resources may incur charges based on usage. The estimated cost for this workshop is approximately **$2 per hour** (~$47 per day), depending on the duration and the specific AWS services utilized.  In a production environment the customer will also incur metered usage for Qumulo software on top of the referenced AWS infrastructure charges. For detailed Qumulo cost estimation please visit the Qumulo AWS TCO Calculator: https://qumulo.com/product/aws/cnq-tco-calculator/  
 
 Please ** Cleanup your Environment ** to avoid excessive charges.  (10_cleanup.html)
 
 A breakdown is as follows:
 
-| Service | Description                                        | Monthly Cost |
-|---------|----------------------------------------------------|-------------:|
-| EC2     | Primary Qumulo Cluster EC2 (i4i.xlarge x 3)        | $751.17      |
-| EC2     | Secondary Qumulo Cluster EC2 (i4i.xlarge x 1)      | $250.39      |
-| EC2     | Windows Workstation (t3.xlarge)                    | $107.84      |
-| EC2     | Linux Workstation (m5.large)                       | $70.08       |
-| EC2     | Load Instances (t3.medium x 5)                     | $253.07      |
-| S3      | Bucket Storage for 30 GB (test data)               | $0.70        |
-|         | **Total Estimated Cost (Monthly)**                 | **$1,433.25**|
+| Service | Description                                        | Hourly Cost |
+|---------|----------------------------------------------------|------------:|
+| EC2     | Primary Qumulo Cluster EC2 (i4i.xlarge x 3)        | $1.03       |
+| EC2     | Secondary Qumulo Cluster EC2 (i4i.xlarge x 1)      | $0.34       |
+| EC2     | Windows Workstation (t3.xlarge)                    | $0.15       |
+| EC2     | Linux Workstation (m5.large)                       | $0.10       |
+| EC2     | Load Instances (t3.medium x 5)                     | $0.35       |
+| S3      | Bucket Storage for 30 GB (test data)               | ~$0.00      |
+|         | **Total Estimated Cost (Hourly)**                  | **~$1.96**  |
 
 ::alert[**Cross-AZ Data Transfer Charges**: When you convert the primary cluster from Single-AZ to Multi-AZ configuration during the workshop, additional data transfer charges will apply for traffic between Availability Zones. These charges are typically $0.01 per GB transferred and are not included in the cost estimate above.]{type="info"}
 


### PR DESCRIPTION
Converts cost breakdown from monthly ($1,433.25/mo) to hourly (~$1.96/hr) to better reflect actual workshop duration (3-4 hours).

Closes #78

**Reviewer finding:** Aaron Dailey persistent storage review, April 8, 2026 (finding #1)