### PR TITLE
Fix easy text issues from Aaron Dailey review

### DIFF
--- a/content/4_elasticity/42_scaleout.md
+++ b/content/4_elasticity/42_scaleout.md
@@ -123,9 +123,7 @@ Access the Qumulo GUI and monitor the following during the node addition operati
 
 ![node add GUI 2](/static/images/elasticity/42_03.png)
 
-::alert[**Why does it appear that no clients are rebalanced to new nodes??** In Multi-AZ clusters we utilize Network Load Balancing to direct clients to nodes.  Stick sessions are enabled and thus existing clients being directed to specific cluster nodes will not immediately get directed to added nodes.  As connections are started, stopped, and added over time they will begin to be directed by AWS NLB to the new nodes.  
-
-In a Single-AZ cluster we use floating IP addresses, those will move with node adds and clients using those migrated floating IPs will immediately begin using the new nodes.]
+::alert[**Why does it appear that no clients are rebalanced to new nodes??** In Multi-AZ clusters we utilize Network Load Balancing to direct clients to nodes. Sticky sessions are enabled and thus existing clients being directed to specific cluster nodes will not immediately get directed to added nodes. As connections are started, stopped, and added over time they will begin to be directed by AWS NLB to the new nodes. In a Single-AZ cluster we use floating IP addresses, those will move with node adds and clients using those migrated floating IPs will immediately begin using the new nodes.]
 
 
 You can also see new nodes in the EC2 console of AWS:

--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -43,7 +43,7 @@ First, we'll create a baseline snapshot of the primary cluster to establish our 
 
 ### **Create the Baseline Snapshot**
 
-1. Navigate to **Cluster > Snapshots** in the left sidebar
+1. Navigate to **Cluster > Saved Snapshots** in the left sidebar
 2. Click **"Take Snapshot"** button in the upper right
 3. Configure the snapshot:
    - **Name**: `userdata_baseline`

--- a/content/5_haanddr/53_replication.md
+++ b/content/5_haanddr/53_replication.md
@@ -163,7 +163,7 @@ Once authorized, the initial synchronization begins automatically:
 
 1. **Return to the primary cluster UI**
 2. Navigate back to **Cluster > Replication**
-3. Observe the relationship status change from "Pending" to "Running"
+3. Observe the relationship status change from "Pending" to "Replicating"
 
 ![Replication Running](/static/images/haanddr/53_09.png)
 
@@ -198,7 +198,7 @@ Monitor the replication progress through:
 
 Let's verify that the target directory is properly configured and receiving data.
 
-### **Create the destination userdata share**
+### **Create the destination userdata share (Secondary Cluster)**
 
 The destination share needs to be created.  
 


### PR DESCRIPTION
Four quick text fixes from Aaron's persistent storage review (April 8, 2026):

- **#91** — `Running` → `Replicating` in replication status text (53_replication.md)
- **#89** — `Snapshots` → `Saved Snapshots` in navigation label (52_snapshots.md)
- **#92** — Add `(Secondary Cluster)` to SMB share creation header (53_replication.md)
- **#86** — Fix broken alert: remove blank line breaking rendering + `Stick` → `Sticky` (42_scaleout.md)

Closes #89
Closes #91
Closes #92
Closes #86