### PR TITLE
Add net use error callouts and cert warning for DR cluster

### DIFF
--- a/content/5_haanddr/51_drclustercreate.md
+++ b/content/5_haanddr/51_drclustercreate.md
@@ -49,7 +49,7 @@ When it finishes, a single EC2 instance boots and automatically forms a Qumulo c
 
 ## Access the cluster
 
-* **Windows Workstation** – open Edge and click the bookmark **“Secondary Qumulo GUI”** (URL `https://demosec.qumulo.local`).  
+* **Windows Workstation** – open Edge and click the bookmark **“Secondary Qumulo GUI”** (URL `https://demosec.qumulo.local`). Accept the certificate warning by clicking **Advanced** → **Continue to demosec.qumulo.local (unsafe)**.  
   The default admin credentials are:
 
   | User | Password |

--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -128,6 +128,8 @@ Policy-generated snapshots use automatic naming:
 
 Connect the Windows system to the share as the admin user: Open **PowerShell** and run:
 
+::alert[**Note:** The `net use /delete` command may show an error if no existing connection exists — this is expected and can be safely ignored.]{type="info"}
+
 ```powershell
 net use \\demopri.qumulo.local\userdata /delete /y
 net use \\demopri.qumulo.local\userdata /user:admin

--- a/content/5_haanddr/53_replication.md
+++ b/content/5_haanddr/53_replication.md
@@ -209,6 +209,8 @@ The destination share needs to be created.
 
 2. **Connect your Windows desktop SMB to the userdata share with admin privileges**
 
+::alert[**Note:** The `net use /delete` commands may show errors if no existing connections exist — this is expected and can be safely ignored.]{type="info"}
+
 ```powershell
 net use \\demopri.qumulo.local\userdata /delete /y
 net use \\demosec.qumulo.local\userdata /delete /y


### PR DESCRIPTION
Three LOW-effort text fixes from Aaron's review:

- **#90** — Add callout that `net use /delete` may fail if no connection exists (52_snapshots.md)
- **#93** — Same callout in replication section (53_replication.md)
- **#88** — Add cert warning text when accessing secondary Qumulo GUI (51_drclustercreate.md)

Closes #90
Closes #93
Closes #88