### PR TITLE
Add Secrets Manager IAM permissions, RDP instructions, and CreateServiceLinkedRole

### DIFF
--- a/content/2_deployment/23_compute_deploy.md
+++ b/content/2_deployment/23_compute_deploy.md
@@ -211,6 +211,9 @@ cat /home/ssm-user/qumulo-workshop/cluster-access-info.txt
 **From the Windows Instance:**
 1. **Navigate to EC2 Console** and locate the instance named **`qumulo-workshop-windows-instance`**
 2. **RDP to Windows instance** using Fleet Manager (username: **Administrator**)
+
+::alert[**Getting the RDP Password:** In the AWS Console, navigate to **Secrets Manager**, search for **QumuloAdmin**, click the secret, then click **Retrieve secret value**. Copy the `password` field and use it as the Administrator password in Fleet Manager RDP.]{type="info"}
+
 3. **Open browser** to the cluster web UI URL: **`https://demopri.qumulo.local`**
 4. **Login** with admin credentials from **`cluster-access-info.txt`** file on the desktop
 

--- a/static/participant_policy.json
+++ b/static/participant_policy.json
@@ -85,6 +85,27 @@
         "elasticloadbalancing:Describe*"
       ],
       "Resource": "*"
+    },
+    {
+      "Sid": "SecretsManagerRead",
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret",
+        "secretsmanager:ListSecrets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Sid": "ServiceLinkedRoleCreation",
+      "Effect": "Allow",
+      "Action": "iam:CreateServiceLinkedRole",
+      "Resource": "arn:aws:iam::*:role/aws-service-role/*",
+      "Condition": {
+        "StringLike": {
+          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
+        }
+      }
     }
   ]
 }


### PR DESCRIPTION
Two BLOCKER fixes from Aaron's persistent storage review:

**#82 — Secrets Manager IAM + RDP password instructions:**
- Added `SecretsManagerRead` statement to `participant_policy.json` (`GetSecretValue`, `DescribeSecret`, `ListSecrets`)
- Added info alert in `23_compute_deploy.md` explaining how to retrieve the RDP password from Secrets Manager (search for `QumuloAdmin`)

**#87 — iam:CreateServiceLinkedRole for scale-in:**
- Added `ServiceLinkedRoleCreation` statement scoped to `elasticloadbalancing.amazonaws.com` so scale-in terraform doesn't fail

Closes #82
Closes #87