### PR TITLE
Remove hardcoded Section X.X number references from navigation links

### DIFF
--- a/content/3_qumulogui/31_getting_started.md
+++ b/content/3_qumulogui/31_getting_started.md
@@ -85,4 +85,4 @@ If you encounter issues connecting:
 
 ---
 
-**Next:** Proceed to **Section 3.2 – Dashboard Overview** where we'll explore the main interface and understand what all those live metrics are telling us about your cluster.
+**Next:** Proceed to **Navigation Overview** where we'll explore the main interface and understand what all those live metrics are telling us about your cluster.

--- a/content/3_qumulogui/32_navigation_overview.md
+++ b/content/3_qumulogui/32_navigation_overview.md
@@ -77,4 +77,4 @@ Take a few minutes to:
 
 ---
 
-**Next:** Proceed to **Section 3.3 – File System Explorer** where we'll dive into browsing and managing your cluster's directory structure.
+**Next:** Proceed to **Analytics Overview** where we'll dive into browsing and managing your cluster's directory structure.

--- a/content/3_qumulogui/33_analytics.md
+++ b/content/3_qumulogui/33_analytics.md
@@ -92,4 +92,4 @@ With your load testing running, explore the Analytics section:
 
 ---
 
-**Next:** Proceed to **Section 3.4 – Sharing Management** where we'll explore how to configure NFS exports, SMB shares, and S3 buckets.
+**Next:** Proceed to **Sharing Management** where we'll explore how to configure NFS exports, SMB shares, and S3 buckets.

--- a/content/3_qumulogui/34_sharing.md
+++ b/content/3_qumulogui/34_sharing.md
@@ -114,4 +114,4 @@ Take a few minutes to explore each section:
 
 ---
 
-**Next:** Proceed to **Section 3.5 – Cluster Administration** where we'll explore system configuration and management tools.
+**Next:** Proceed to **Cluster Administration** where we'll explore system configuration and management tools.

--- a/content/3_qumulogui/35_cluster.md
+++ b/content/3_qumulogui/35_cluster.md
@@ -96,4 +96,4 @@ Take time to explore the Cluster section:
 
 ---
 
-**Next:** Proceed to **Section 3.6 – APIs & Tools** where we'll explore developer resources and automation capabilities.
+**Next:** Proceed to **APIs & Tools** where we'll explore developer resources and automation capabilities.

--- a/content/3_qumulogui/36_api_and_tools.md
+++ b/content/3_qumulogui/36_api_and_tools.md
@@ -64,4 +64,4 @@ Take a few minutes to explore the API documentation:
 
 ---
 
-**Next:** Proceed to **Section 3.7 – Support Resources** where we'll explore help documentation and troubleshooting tools.
+**Next:** Proceed to **Support Resources** where we'll explore help documentation and troubleshooting tools.

--- a/content/3_qumulogui/37_support.md
+++ b/content/3_qumulogui/37_support.md
@@ -56,4 +56,4 @@ Manage cluster software updates directly from the interface:
 
 **Congratulations!** You've completed the Qumulo GUI overview. You now understand the interface layout and key capabilities available through the web console.
 
-**Next:** Proceed to **Section 4 - Scaling Qumulo in the Cloud** where we'll explore Qumulo's dynamic scaling capabilities and learn how to add and remove nodes from your cluster.
+**Next:** Proceed to **Scaling Qumulo in the Cloud** where we'll explore Qumulo's dynamic scaling capabilities and learn how to add and remove nodes from your cluster.

--- a/content/5_haanddr/51_drclustercreate.md
+++ b/content/5_haanddr/51_drclustercreate.md
@@ -90,6 +90,6 @@ You should see **exactly one node** in the output, confirming the single-node de
 
 ## Next step
 
-Proceed to **Section 5.2 – Snapshot Management** where you will create snapshots on both clusters and begin configuring replication.
+Proceed to **Snapshot Management** where you will create snapshots on both clusters and begin configuring replication.
 
 ---

--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -266,6 +266,6 @@ As you work through this section, note these important characteristics:
 
 ## Next Steps
 
-In **Section 5.3**, we'll configure continuous replication relationships between your primary and secondary clusters, using snapshots as the foundation for cross-cluster data protection.
+In the next section, we'll configure continuous replication relationships between your primary and secondary clusters, using snapshots as the foundation for cross-cluster data protection.
 
 ::alert[**Best Practice**: In production environments, consider multiple snapshot policies with different frequencies and retention periods - for example, frequent snapshots for recent changes and longer-term snapshots for historical recovery points.]

--- a/content/5_haanddr/53_replication.md
+++ b/content/5_haanddr/53_replication.md
@@ -339,6 +339,6 @@ Once the relationship is removed, the target directory is instantly switched fro
 
 ## Next step
 
-Proceed to **Section 6.0 – Cloud Data Fabric** explore Qumulo's Cloud Data Fabric (CDF) technology.
+Proceed to **Cloud Data Fabric (CDF)** to explore Qumulo's Cloud Data Fabric (CDF) technology.
 
 ---

--- a/content/6_cdf/_index.md
+++ b/content/6_cdf/_index.md
@@ -198,6 +198,6 @@ Check for this data on the hub which was written to the spoke.  Notice the size 
 
 ## Next step
 
-Proceed to **Section 10.0 – Resource Cleanup** to end the workshop and cleanup the environment.
+Proceed to **Resource Cleanup** to end the workshop and cleanup the environment.
 
 ::alert[The examples, scripts, and sample code provided in this workshop are intended for instructional use in a controlled environment. For production deployments, always consult your Qumulo or AWS account teams for recommended practices and cluster provisioning.]{type="warning"}


### PR DESCRIPTION
Removes section numbers from 11 'Proceed to' navigation links across the workshop so they match Workshop Studio sidebar labels.

Also fixes two incorrect page titles and one grammar issue:
- `31_getting_started.md`: 'Dashboard Overview' → **Navigation Overview**
- `32_navigation_overview.md`: 'File System Explorer' → **Analytics Overview**
- `53_replication.md`: 'Cloud Data Fabric' → **Cloud Data Fabric (CDF)** + fixed missing 'to'

Closes #85