### PR TITLE
Fix SSM parameter descriptions and add cert warning screenshot

### DIFF
--- a/content/2_deployment/22_storage_deploy.md
+++ b/content/2_deployment/22_storage_deploy.md
@@ -108,10 +108,11 @@ The persistent storage deployment creates **Systems Manager (SSM) parameters** t
 The persistent storage deployment creates several critical parameters:
 
 **Storage Configuration Parameters:**
-- **Storage bucket names** - List of all created S3 buckets
-- **Deployment unique name** - Identifier linking storage to compute
-- **Storage configuration** - Technical settings for bucket access
-- **Encryption keys** - KMS key information for data encryption
+- **bucket-arns** - ARNs of the S3 buckets created for persistent storage
+- **bucket-names** - Names of the S3 buckets
+- **bucket-region** - AWS region where buckets are located
+- **bucket-uris** - S3 URIs for bucket access
+- **soft-capacity-limit** - Storage capacity configuration
 
 ![storage SSM parameter store detail](/static/images/deployment/22_05.png)
 
@@ -126,7 +127,7 @@ These parameters follow a specific naming convention:
 **How Compute Uses These Parameters:**
 - **Bucket Discovery**: Compute infrastructure reads bucket names from parameters
 - **Configuration Consistency**: Ensures compute and storage configurations match
-- **Security**: Encryption keys and access patterns stored securely
+- **Security**: All parameter values are stored as encrypted SecureStrings
 
 ::alert[**Workshop Note**: These parameters are automatically created and managed by Terraform. Manual modification can break the connection between storage and compute infrastructure.]{type="warning"}
 

--- a/content/2_deployment/23_compute_deploy.md
+++ b/content/2_deployment/23_compute_deploy.md
@@ -215,7 +215,11 @@ cat /home/ssm-user/qumulo-workshop/cluster-access-info.txt
 ::alert[**Getting the RDP Password:** In the AWS Console, navigate to **Secrets Manager**, search for **QumuloAdmin**, click the secret, then click **Retrieve secret value**. Copy the `password` field and use it as the Administrator password in Fleet Manager RDP.]{type="info"}
 
 3. **Open browser** to the cluster web UI URL: **`https://demopri.qumulo.local`**
-4. **Login** with admin credentials from **`cluster-access-info.txt`** file on the desktop
+4. **Accept the certificate warning** — the workshop uses a self-signed certificate. Click **Advanced** → **Continue to demopri.qumulo.local (unsafe)**.
+
+![Qumulo Certificate Error](/static/images/qumulogui/31_04.png)
+
+5. **Login** with admin credentials from **`cluster-access-info.txt`** file on the desktop
 
 ![locate the windows instance connect button](/static/images/deployment/23_12.png)
 


### PR DESCRIPTION
**#79** — Replace generic SSM parameter descriptions in `22_storage_deploy.md` with actual parameter names verified against live deployment:
- `bucket-arns`, `bucket-names`, `bucket-region`, `bucket-uris`, `soft-capacity-limit`
- Removes non-existent 'Encryption keys', 'Deployment unique name', 'Storage configuration'

**#84** — Add certificate warning step + existing screenshot (`31_04.png`) to `23_compute_deploy.md` between 'Open browser' and 'Login' steps, where users first hit the self-signed cert.

Closes #79
Closes #84