### PR TITLE
Add iam:CreateServiceLinkedRole to EC2 instance role — fixes MAZ/scale-out

### DIFF
--- a/static/infrastructure/qumulo-workshop-deployment-cft.yaml
+++ b/static/infrastructure/qumulo-workshop-deployment-cft.yaml
@@ -549,6 +549,15 @@ Resources:
               # Includes: EC2, ELB, IAM (except PassRole), CloudWatch, Route53,
               #           Resource Groups, KMS, STS, CloudFormation, and Tags
               # ------------------------------------------------------------------
+              - Sid: AllowELBServiceLinkedRoleCreation
+                Effect: Allow
+                Action:
+                  - iam:CreateServiceLinkedRole
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    iam:AWSServiceName: elasticloadbalancing.amazonaws.com
+
               - Effect: Allow
                 Action:
                   - cloudformation:DescribeStackResources


### PR DESCRIPTION
**BLOCKER** — The EC2 instance role used by Terraform was missing `iam:CreateServiceLinkedRole`, causing MAZ conversion, scale-out, and any NLB creation to fail.

Added scoped permission per Aaron's recommendation:
```yaml
- Sid: AllowELBServiceLinkedRoleCreation
  Effect: Allow
  Action: iam:CreateServiceLinkedRole
  Resource: "*"
  Condition:
    StringEquals:
      iam:AWSServiceName: elasticloadbalancing.amazonaws.com
```

**Note:** This fixes new events. Existing running events need manual IAM role patch or re-provisioning.

Closes #102