### PR TITLE
Fix SSM search pattern — add -str suffix to show only storage params

### DIFF
--- a/content/2_deployment/22_storage_deploy.md
+++ b/content/2_deployment/22_storage_deploy.md
@@ -99,7 +99,7 @@ The persistent storage deployment creates **Systems Manager (SSM) parameters** t
 
 1. **Navigate to Systems Manager** in the AWS Console
 2. **Select Parameter Store** from the left navigation
-3. **Filter parameters** by your deployment unique name ```/qumulo/qum-wks-cls-pri```
+3. **Filter parameters** by your storage deployment name ```/qumulo/qum-wks-cls-pri-str```
 
 ![storage SSM parameter store](/static/images/deployment/22_04.png)
 


### PR DESCRIPTION
Changes `/qumulo/qum-wks-cls-pri` to `/qumulo/qum-wks-cls-pri-str` in `22_storage_deploy.md` so the Parameter Store filter shows only the 5 storage parameters, matching the screenshot.

Closes #104