### PR TITLE
Add security callout for plaintext password in terraform.tfvars

### DIFF
--- a/content/2_deployment/23_compute_deploy.md
+++ b/content/2_deployment/23_compute_deploy.md
@@ -68,6 +68,8 @@ cat terraform.tfvars
 - **`q_cluster_version`** - Qumulo software version
 - **`q_cluster_admin_password`** - Administrative password
 
+::alert[**Production Security Note:** The `q_cluster_admin_password` is stored in plaintext in `terraform.tfvars` for initial cluster deployment. This is standard practice for Qumulo's initial provisioning — after deployment, Qumulo recommends [changing the cluster admin password](https://docs.qumulo.com/cloud-native-aws-administrator-guide/getting-started/terraform.html) via the Qumulo UI and updating the corresponding value in **AWS Secrets Manager**. Terraform uses the Secrets Manager value for all subsequent cluster operations. For production environments, also consider using [Terraform sensitive variables](https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables) to avoid storing passwords in plaintext configuration files.]{type="warning"}
+
 **Qumulo Cluster Config Options**
 - **`q_persistent_storage_type`** - Storage backend type (default to hot_s3_int)
 - **`q_instance_type`** - EC2 instance type (i4i.xlarge for workshop, not recommended for production)

--- a/content/4_elasticity/41_saztomaz.md
+++ b/content/4_elasticity/41_saztomaz.md
@@ -81,6 +81,8 @@ You will notice the original cluster var file has been copied over and we've upd
 ![maz tfvars 1](/static/images/elasticity/41_03.png)
 ![maz tfvars 2](/static/images/elasticity/41_04.png)
 
+::alert[**Note:** The `q_cluster_admin_password` visible in the tfvars is the initial deployment password. Terraform uses the password stored in **Secrets Manager** for all subsequent cluster operations. See the security note in the [Compute Deployment](/2_deployment/23_compute_deploy.html) section for production best practices.]{type="info"}
+
 ---
 
 ## **Step 2: Execute Cluster Replace Operation**


### PR DESCRIPTION
Per Aaron/Tim/Gokul discussion: keep the plaintext password in tfvars (Qumulo's standard pattern) but add documentation callouts.

**`23_compute_deploy.md`** — Warning callout after `q_cluster_admin_password` explaining:
1. This is Qumulo's standard initial deployment practice
2. Post-deployment, change password via Qumulo UI and update Secrets Manager
3. Terraform uses Secrets Manager for all subsequent operations
4. Link to [Terraform sensitive variables best practices](https://developer.hashicorp.com/terraform/tutorials/configuration-language/sensitive-variables)

**`41_saztomaz.md`** — Info callout after MAZ tfvars screenshots referencing the main security note.

Closes #103