### PR TITLE
Aaron final 3: cleanup link, snapshot naming, remove unused IAM

### DIFF
--- a/content/5_haanddr/52_snapshots.md
+++ b/content/5_haanddr/52_snapshots.md
@@ -117,8 +117,8 @@ Watch the automated policy create snapshots over the next few minutes.
 ### **Snapshot Naming Convention**
 
 Policy-generated snapshots use automatic naming:
-- **Format**: `policy-name_YYYY-MM-DD_HH-MM-SS`
-- **Example**: `frequent-protection_2025-07-25_15-10-00`
+- **Format**: `policy-name_sharename`
+- **Example**: `frequent-protection_userdata`
 
 ![snapshots](/static/images/haanddr/52_05.png)
 

--- a/content/_index.md
+++ b/content/_index.md
@@ -46,7 +46,7 @@ The diagram below illustrates the environment that is deployed throughout the wo
 ## **Estimated Workshop Cost**
 This workshop is designed to be cost-effective. However, please note that running AWS resources may incur charges based on usage. The estimated cost for this workshop is approximately **$2 per hour** (~$47 per day), depending on the duration and the specific AWS services utilized.  In a production environment the customer will also incur metered usage for Qumulo software on top of the referenced AWS infrastructure charges. For detailed Qumulo cost estimation please visit the Qumulo AWS TCO Calculator: https://qumulo.com/product/aws/cnq-tco-calculator/  
 
-Please ** Cleanup your Environment ** to avoid excessive charges.  (10_cleanup.html)
+Please [**Cleanup your Environment**](/10_cleanup.html) to avoid excessive charges.
 
 A breakdown is as follows:
 

--- a/static/participant_policy.json
+++ b/static/participant_policy.json
@@ -95,17 +95,6 @@
         "secretsmanager:ListSecrets"
       ],
       "Resource": "*"
-    },
-    {
-      "Sid": "ServiceLinkedRoleCreation",
-      "Effect": "Allow",
-      "Action": "iam:CreateServiceLinkedRole",
-      "Resource": "arn:aws:iam::*:role/aws-service-role/*",
-      "Condition": {
-        "StringLike": {
-          "iam:AWSServiceName": "elasticloadbalancing.amazonaws.com"
-        }
-      }
     }
   ]
 }


### PR DESCRIPTION
Aaron's final review items (non-blocking, workshop approved):

1. **Cleanup link** (`_index.md`) — broken text `(10_cleanup.html)` → proper markdown link
2. **Snapshot naming** (`52_snapshots.md`) — format was `policy-name_YYYY-MM-DD_HH-MM-SS` but screenshot shows `sequence_policy-name_sharename`
3. **participant_policy.json** — remove `ServiceLinkedRoleCreation` (only needed on EC2 instance role, already added to CFT in PR #105)